### PR TITLE
feat(type-info): Add support for JsonTypeInfoAs.EXTERNAL_PROPERTY

### DIFF
--- a/src/decorators/JsonTypeInfo.ts
+++ b/src/decorators/JsonTypeInfo.ts
@@ -37,7 +37,16 @@ export enum JsonTypeInfoAs {
    * in a 2-element JSON array: first element is the serialized type identifier,
    * and second element the serialized Class as JSON Object.
    */
-  WRAPPER_ARRAY
+  WRAPPER_ARRAY,
+  /**
+   * Inclusion mechanism similar to `PROPERTY`, except that
+   * property is included one-level higher in hierarchy, i.e. as sibling
+   * property at same level as JSON Object to type.
+   * Note that this choice **can only be used for properties**, not
+   * for types (classes). Trying to use it for classes will result in
+   * inclusion strategy of basic `PROPERTY` instead.
+   */
+  EXTERNAL_PROPERTY
 }
 
 /**

--- a/tests/JsonTypes.ts
+++ b/tests/JsonTypes.ts
@@ -1002,3 +1002,866 @@ test('@JsonTypeInfo with JsonTypeInfoAs.WRAPPER_ARRAY', t => {
   t.assert(animals[1] instanceof Cat);
   t.is(animals[1].name, 'Merlin');
 });
+
+test('@JsonTypeInfo and @JsonSubTypes at class level with JsonTypeInfoAs.EXTERNAL_PROPERTY without subtypes name', t => {
+  @JsonTypeInfo({
+    use: JsonTypeInfoId.NAME,
+    include: JsonTypeInfoAs.EXTERNAL_PROPERTY
+  })
+  @JsonSubTypes({
+    types: [
+      {class: () => Dog},
+      {class: () => Cat},
+    ]
+  })
+  class Animal {
+    @JsonProperty() @JsonClassType({type: () => [String]})
+    name: string;
+
+    constructor(name: string) {
+      this.name = name;
+    }
+  }
+
+  class Dog extends Animal {
+
+  }
+
+  class Cat extends Animal {
+
+  }
+
+  const dog = new Dog('Arthur');
+  const cat = new Cat('Merlin');
+
+  const objectMapper = new ObjectMapper();
+  const jsonData = objectMapper.stringify<Array<Animal>>([dog, cat]);
+  t.deepEqual(JSON.parse(jsonData), JSON.parse('[{"name":"Arthur","@type":"Dog"},{"name":"Merlin","@type":"Cat"}]'));
+
+  const animals = objectMapper.parse<Array<Animal>>(jsonData, {mainCreator: () => [Array, [Animal]]});
+  t.assert(animals instanceof Array);
+  t.is(animals.length, 2);
+  t.assert(animals[0] instanceof Dog);
+  t.is(animals[0].name, 'Arthur');
+  t.assert(animals[1] instanceof Cat);
+  t.is(animals[1].name, 'Merlin');
+});
+
+test('@JsonTypeInfo at class level with JsonTypeInfoAs.EXTERNAL_PROPERTY without subtypes name and using a custom @JsonTypeIdResolver', t => {
+  class CustomTypeIdResolver implements TypeIdResolver {
+    idFromValue(obj: any, options: (JsonStringifierTransformerContext | JsonParserTransformerContext)): string {
+      if (obj instanceof Dog) {
+        return 'animalDogType';
+      } else if (obj instanceof Cat) {
+        return 'animalCatType';
+      }
+      return null;
+    }
+    typeFromId(id: string, options: (JsonStringifierTransformerContext | JsonParserTransformerContext)): ClassType<any> {
+      switch (id) {
+      case 'animalDogType':
+        return Dog;
+      case 'animalCatType':
+        return Cat;
+      }
+      return null;
+    };
+  }
+
+  @JsonTypeInfo({
+    use: JsonTypeInfoId.NAME,
+    include: JsonTypeInfoAs.EXTERNAL_PROPERTY
+  })
+  @JsonTypeIdResolver({resolver: new CustomTypeIdResolver()})
+  class Animal {
+    @JsonProperty() @JsonClassType({type: () => [String]})
+    name: string;
+
+    constructor(name: string) {
+      this.name = name;
+    }
+  }
+
+  class Dog extends Animal {
+
+  }
+
+  class Cat extends Animal {
+
+  }
+
+  const dog = new Dog('Arthur');
+  const cat = new Cat('Merlin');
+
+  const objectMapper = new ObjectMapper();
+  const jsonData = objectMapper.stringify<Array<Animal>>([dog, cat]);
+  t.deepEqual(JSON.parse(jsonData), JSON.parse('[{"name":"Arthur","@type":"animalDogType"},{"name":"Merlin","@type":"animalCatType"}]'));
+
+  const animals = objectMapper.parse<Array<Animal>>(jsonData, {mainCreator: () => [Array, [Animal]]});
+  t.assert(animals instanceof Array);
+  t.is(animals.length, 2);
+  t.assert(animals[0] instanceof Dog);
+  t.is(animals[0].name, 'Arthur');
+  t.assert(animals[1] instanceof Cat);
+  t.is(animals[1].name, 'Merlin');
+});
+
+test('@JsonTypeInfo and @JsonSubTypes at property level with JsonTypeInfoAs.EXTERNAL_PROPERTY without subtypes name', t => {
+  class Zoo {
+    @JsonTypeInfo({
+      use: JsonTypeInfoId.NAME,
+      include: JsonTypeInfoAs.EXTERNAL_PROPERTY,
+      property: 'animalType',
+    })
+    @JsonSubTypes({
+      types: [
+        {class: () => Dog},
+        {class: () => Cat},
+      ]
+    })
+    @JsonProperty()
+    @JsonClassType({type: () => [Animal]})
+    animal: Animal;
+  }
+
+  class Animal {
+    @JsonProperty() @JsonClassType({type: () => [String]})
+    name: string;
+
+    constructor(name: string) {
+      this.name = name;
+    }
+  }
+
+  class Dog extends Animal {
+    @JsonProperty()
+    @JsonClassType({type: () => [Dog]})
+    father: Dog;
+    @JsonProperty()
+    @JsonClassType({type: () => [Dog]})
+    mother: Dog;
+  }
+
+  class Cat extends Animal {
+
+  }
+
+  const zoo = new Zoo();
+  const dog = new Dog('Arthur');
+  const fatherDog = new Dog('Buddy');
+  const motherDog = new Dog('Coco');
+  dog.father = fatherDog;
+  dog.mother = motherDog;
+  zoo.animal = dog;
+
+  const objectMapper = new ObjectMapper();
+  const jsonData = objectMapper.stringify<Zoo>(zoo);
+  // eslint-disable-next-line max-len
+  t.deepEqual(JSON.parse(jsonData), JSON.parse('{"animal":{"name":"Arthur","father":{"name":"Buddy"},"mother":{"name":"Coco"}},"animalType":"Dog"}'));
+
+  const zooParsed = objectMapper.parse<Zoo>(jsonData, {mainCreator: () => [Zoo]});
+  t.assert(zooParsed instanceof Zoo);
+  t.assert(zooParsed.animal instanceof Dog);
+  t.is(zooParsed.animal.name, 'Arthur');
+  t.assert((zooParsed.animal as Dog).father instanceof Dog);
+  t.is((zooParsed.animal as Dog).father.name, 'Buddy');
+  t.assert((zooParsed.animal as Dog).mother instanceof Dog);
+  t.is((zooParsed.animal as Dog).mother.name, 'Coco');
+});
+
+test('@JsonTypeInfo and @JsonSubTypes at method level with JsonTypeInfoAs.EXTERNAL_PROPERTY without subtypes name', t => {
+  class Zoo {
+    @JsonProperty()
+    @JsonClassType({type: () => [Animal]})
+    animal: Animal;
+
+    @JsonGetter()
+    @JsonTypeInfo({
+      use: JsonTypeInfoId.NAME,
+      include: JsonTypeInfoAs.EXTERNAL_PROPERTY,
+      property: 'animalType',
+    })
+    @JsonSubTypes({
+      types: [
+        {class: () => Dog},
+        {class: () => Cat},
+      ]
+    })
+    @JsonClassType({type: () => [Animal]})
+    getAnimal(): Animal {
+      return this.animal;
+    }
+
+    @JsonSetter()
+    @JsonTypeInfo({
+      use: JsonTypeInfoId.NAME,
+      include: JsonTypeInfoAs.EXTERNAL_PROPERTY,
+      property: 'animalType',
+    })
+    @JsonSubTypes({
+      types: [
+        {class: () => Dog},
+        {class: () => Cat},
+      ]
+    })
+    setAnimal(@JsonClassType({type: () => [Animal]}) animal) {
+      this.animal = animal;
+    }
+  }
+
+  class Animal {
+    @JsonProperty() @JsonClassType({type: () => [String]})
+    name: string;
+
+    constructor(name: string) {
+      this.name = name;
+    }
+  }
+
+  class Dog extends Animal {
+
+  }
+
+  class Cat extends Animal {
+
+  }
+
+  const zoo = new Zoo();
+  const dog = new Dog('Arthur');
+  zoo.animal = dog;
+
+  const objectMapper = new ObjectMapper();
+  const jsonData = objectMapper.stringify<Zoo>(zoo);
+  // eslint-disable-next-line max-len
+  t.deepEqual(JSON.parse(jsonData), JSON.parse('{"animal":{"name":"Arthur"},"animalType":"Dog"}'));
+
+  const zooParsed = objectMapper.parse<Zoo>(jsonData, {mainCreator: () => [Zoo]});
+  t.assert(zooParsed instanceof Zoo);
+  t.assert(zooParsed.animal instanceof Dog);
+  t.is(zooParsed.animal.name, 'Arthur');
+});
+
+test('@JsonTypeInfo at property level with JsonTypeInfoAs.EXTERNAL_PROPERTY without subtypes name and using a custom @JsonTypeIdResolver', t => {
+  class CustomTypeIdResolver implements TypeIdResolver {
+    idFromValue(obj: any, options: (JsonStringifierTransformerContext | JsonParserTransformerContext)): string {
+      if (obj instanceof Dog) {
+        return 'animalDogType';
+      }
+      return null;
+    }
+    typeFromId(id: string, options: (JsonStringifierTransformerContext | JsonParserTransformerContext)): ClassType<any> {
+      switch (id) {
+      case 'animalDogType':
+        return Dog;
+      }
+      return null;
+    };
+  }
+
+  class Zoo {
+    @JsonTypeInfo({
+      use: JsonTypeInfoId.NAME,
+      include: JsonTypeInfoAs.EXTERNAL_PROPERTY,
+      property: 'animalType',
+    })
+    @JsonTypeIdResolver({resolver: new CustomTypeIdResolver()})
+    @JsonProperty()
+    @JsonClassType({type: () => [Animal]})
+    animal: Animal;
+  }
+
+  class Animal {
+    @JsonProperty() @JsonClassType({type: () => [String]})
+    name: string;
+
+    constructor(name: string) {
+      this.name = name;
+    }
+  }
+
+  class Dog extends Animal {
+    @JsonProperty()
+    @JsonClassType({type: () => [Dog]})
+    father: Dog;
+    @JsonProperty()
+    @JsonClassType({type: () => [Dog]})
+    mother: Dog;
+  }
+
+  const zoo = new Zoo();
+  const dog = new Dog('Arthur');
+  const fatherDog = new Dog('Buddy');
+  const motherDog = new Dog('Coco');
+  dog.father = fatherDog;
+  dog.mother = motherDog;
+  zoo.animal = dog;
+
+  const objectMapper = new ObjectMapper();
+  const jsonData = objectMapper.stringify<Zoo>(zoo);
+  // eslint-disable-next-line max-len
+  t.deepEqual(JSON.parse(jsonData), JSON.parse('{"animal":{"name":"Arthur","father":{"name":"Buddy"},"mother":{"name":"Coco"}},"animalType":"animalDogType"}'));
+
+  const zooParsed = objectMapper.parse<Zoo>(jsonData, {mainCreator: () => [Zoo]});
+  t.assert(zooParsed instanceof Zoo);
+  t.assert(zooParsed.animal instanceof Dog);
+  t.is(zooParsed.animal.name, 'Arthur');
+  t.assert((zooParsed.animal as Dog).father instanceof Dog);
+  t.is((zooParsed.animal as Dog).father.name, 'Buddy');
+  t.assert((zooParsed.animal as Dog).mother instanceof Dog);
+  t.is((zooParsed.animal as Dog).mother.name, 'Coco');
+});
+
+test('@JsonTypeInfo at method level with JsonTypeInfoAs.EXTERNAL_PROPERTY without subtypes name and using a custom @JsonTypeIdResolver', t => {
+  class CustomTypeIdResolver implements TypeIdResolver {
+    idFromValue(obj: any, options: (JsonStringifierTransformerContext | JsonParserTransformerContext)): string {
+      if (obj instanceof Dog) {
+        return 'animalDogType';
+      }
+      return null;
+    }
+    typeFromId(id: string, options: (JsonStringifierTransformerContext | JsonParserTransformerContext)): ClassType<any> {
+      switch (id) {
+      case 'animalDogType':
+        return Dog;
+      }
+      return null;
+    };
+  }
+
+  class Zoo {
+    @JsonProperty()
+    @JsonClassType({type: () => [Animal]})
+    animal: Animal;
+
+    @JsonGetter()
+    @JsonTypeInfo({
+      use: JsonTypeInfoId.NAME,
+      include: JsonTypeInfoAs.EXTERNAL_PROPERTY,
+      property: 'animalType',
+    })
+    @JsonTypeIdResolver({resolver: new CustomTypeIdResolver()})
+    @JsonClassType({type: () => [Animal]})
+    getAnimal(): Animal {
+      return this.animal;
+    }
+
+    @JsonSetter()
+    @JsonTypeInfo({
+      use: JsonTypeInfoId.NAME,
+      include: JsonTypeInfoAs.EXTERNAL_PROPERTY,
+      property: 'animalType',
+    })
+    @JsonTypeIdResolver({resolver: new CustomTypeIdResolver()})
+    setAnimal(@JsonClassType({type: () => [Animal]}) animal) {
+      this.animal = animal;
+    }
+  }
+
+  class Animal {
+    @JsonProperty() @JsonClassType({type: () => [String]})
+    name: string;
+
+    constructor(name: string) {
+      this.name = name;
+    }
+  }
+
+  class Dog extends Animal {
+    @JsonProperty()
+    @JsonClassType({type: () => [Dog]})
+    father: Dog;
+    @JsonProperty()
+    @JsonClassType({type: () => [Dog]})
+    mother: Dog;
+  }
+
+  const zoo = new Zoo();
+  const dog = new Dog('Arthur');
+  const fatherDog = new Dog('Buddy');
+  const motherDog = new Dog('Coco');
+  dog.father = fatherDog;
+  dog.mother = motherDog;
+  zoo.animal = dog;
+
+  const objectMapper = new ObjectMapper();
+  const jsonData = objectMapper.stringify<Zoo>(zoo);
+  // eslint-disable-next-line max-len
+  t.deepEqual(JSON.parse(jsonData), JSON.parse('{"animal":{"name":"Arthur","father":{"name":"Buddy"},"mother":{"name":"Coco"}},"animalType":"animalDogType"}'));
+
+  const zooParsed = objectMapper.parse<Zoo>(jsonData, {mainCreator: () => [Zoo]});
+  t.assert(zooParsed instanceof Zoo);
+  t.assert(zooParsed.animal instanceof Dog);
+  t.is(zooParsed.animal.name, 'Arthur');
+  t.assert((zooParsed.animal as Dog).father instanceof Dog);
+  t.is((zooParsed.animal as Dog).father.name, 'Buddy');
+  t.assert((zooParsed.animal as Dog).mother instanceof Dog);
+  t.is((zooParsed.animal as Dog).mother.name, 'Coco');
+});
+
+test('@JsonTypeInfo and @JsonSubTypes at parameter level with JsonTypeInfoAs.EXTERNAL_PROPERTY without subtypes name', t => {
+  class Zoo {
+    @JsonProperty()
+    @JsonClassType({type: () => [Animal]})
+    animal: Animal;
+
+    constructor(
+    @JsonTypeInfo({
+      use: JsonTypeInfoId.NAME,
+      include: JsonTypeInfoAs.EXTERNAL_PROPERTY,
+      property: 'animalType',
+    })
+    @JsonSubTypes({
+      types: [
+        {class: () => Dog},
+        {class: () => Cat},
+      ]
+    })
+    @JsonClassType({type: () => [Animal]})
+      animal: Animal) {
+      this.animal = animal;
+    }
+  }
+
+  class Animal {
+    @JsonProperty() @JsonClassType({type: () => [String]})
+    name: string;
+
+    constructor(name: string) {
+      this.name = name;
+    }
+  }
+
+  class Dog extends Animal {
+    @JsonProperty()
+    @JsonClassType({type: () => [Dog]})
+    father: Dog;
+    @JsonProperty()
+    @JsonClassType({type: () => [Dog]})
+    mother: Dog;
+  }
+
+  class Cat extends Animal {
+
+  }
+
+  const objectMapper = new ObjectMapper();
+  // eslint-disable-next-line max-len
+  const jsonData = '{"animal":{"name":"Arthur","father":{"name":"Buddy"},"mother":{"name":"Coco"}},"animalType":"Dog"}';
+
+  const zooParsed = objectMapper.parse<Zoo>(jsonData, {mainCreator: () => [Zoo]});
+  t.assert(zooParsed instanceof Zoo);
+  t.assert(zooParsed.animal instanceof Dog);
+  t.is(zooParsed.animal.name, 'Arthur');
+  t.assert((zooParsed.animal as Dog).father instanceof Dog);
+  t.is((zooParsed.animal as Dog).father.name, 'Buddy');
+  t.assert((zooParsed.animal as Dog).mother instanceof Dog);
+  t.is((zooParsed.animal as Dog).mother.name, 'Coco');
+});
+
+test('@JsonTypeInfo at parameter level with JsonTypeInfoAs.EXTERNAL_PROPERTY without subtypes name and using a custom @JsonTypeIdResolver', t => {
+  class CustomTypeIdResolver implements TypeIdResolver {
+    idFromValue(obj: any, options: (JsonStringifierTransformerContext | JsonParserTransformerContext)): string {
+      if (obj instanceof Dog) {
+        return 'animalDogType';
+      } else if (obj instanceof Cat) {
+        return 'animalCatType';
+      }
+      return null;
+    }
+    typeFromId(id: string, options: (JsonStringifierTransformerContext | JsonParserTransformerContext)): ClassType<any> {
+      switch (id) {
+      case 'animalDogType':
+        return Dog;
+      case 'animalCatType':
+        return Cat;
+      }
+      return null;
+    };
+  }
+
+  class Zoo {
+    @JsonProperty()
+    @JsonClassType({type: () => [Animal]})
+    animal: Animal;
+
+    constructor(
+    @JsonTypeInfo({
+      use: JsonTypeInfoId.NAME,
+      include: JsonTypeInfoAs.EXTERNAL_PROPERTY,
+      property: 'animalType',
+    })
+    @JsonTypeIdResolver({resolver: new CustomTypeIdResolver()})
+    @JsonClassType({type: () => [Animal]})
+      animal: Animal) {
+      this.animal = animal;
+    }
+  }
+
+  class Animal {
+    @JsonProperty() @JsonClassType({type: () => [String]})
+    name: string;
+
+    constructor(name: string) {
+      this.name = name;
+    }
+  }
+
+  class Dog extends Animal {
+    @JsonProperty()
+    @JsonClassType({type: () => [Dog]})
+    father: Dog;
+    @JsonProperty()
+    @JsonClassType({type: () => [Dog]})
+    mother: Dog;
+  }
+
+  class Cat extends Animal {
+
+  }
+
+  const objectMapper = new ObjectMapper();
+  // eslint-disable-next-line max-len
+  const jsonData = '{"animal":{"name":"Arthur","father":{"name":"Buddy"},"mother":{"name":"Coco"}},"animalType":"animalDogType"}';
+
+  const zooParsed = objectMapper.parse<Zoo>(jsonData, {mainCreator: () => [Zoo]});
+  t.assert(zooParsed instanceof Zoo);
+  t.assert(zooParsed.animal instanceof Dog);
+  t.is(zooParsed.animal.name, 'Arthur');
+  t.assert((zooParsed.animal as Dog).father instanceof Dog);
+  t.is((zooParsed.animal as Dog).father.name, 'Buddy');
+  t.assert((zooParsed.animal as Dog).mother instanceof Dog);
+  t.is((zooParsed.animal as Dog).mother.name, 'Coco');
+});
+
+test('@JsonTypeInfo at parameter level (inside @JsonClass) with JsonTypeInfoAs.EXTERNAL_PROPERTY without subtypes name', t => {
+  class Zoo {
+    @JsonProperty()
+    @JsonClassType({type: () => [Animal]})
+    animal: Animal;
+
+    constructor(
+    @JsonClassType({type: () => [
+      () => ({
+        target: Animal,
+        decorators: [
+          {
+            name: 'JsonTypeInfo',
+            options: {
+              use: JsonTypeInfoId.NAME,
+              include: JsonTypeInfoAs.EXTERNAL_PROPERTY,
+              property: 'animalType'
+            }
+          },
+          {
+            name: 'JsonSubTypes',
+            options: {
+              types: [
+                {class: () => Dog},
+                {class: () => Cat},
+              ]
+            }
+          }
+        ]
+      })
+    ]})
+      animal: Animal) {
+      this.animal = animal;
+    }
+  }
+
+  class Animal {
+    @JsonProperty() @JsonClassType({type: () => [String]})
+    name: string;
+
+    constructor(name: string) {
+      this.name = name;
+    }
+  }
+
+  class Dog extends Animal {
+    @JsonProperty()
+    @JsonClassType({type: () => [Dog]})
+    father: Dog;
+    @JsonProperty()
+    @JsonClassType({type: () => [Dog]})
+    mother: Dog;
+  }
+
+  class Cat extends Animal {
+
+  }
+
+  const objectMapper = new ObjectMapper();
+  // eslint-disable-next-line max-len
+  const jsonData = '{"animal":{"name":"Arthur","father":{"name":"Buddy"},"mother":{"name":"Coco"}},"animalType":"Dog"}';
+
+  const zooParsed = objectMapper.parse<Zoo>(jsonData, {mainCreator: () => [Zoo]});
+  t.assert(zooParsed instanceof Zoo);
+  t.assert(zooParsed.animal instanceof Dog);
+  t.is(zooParsed.animal.name, 'Arthur');
+  t.assert((zooParsed.animal as Dog).father instanceof Dog);
+  t.is((zooParsed.animal as Dog).father.name, 'Buddy');
+  t.assert((zooParsed.animal as Dog).mother instanceof Dog);
+  t.is((zooParsed.animal as Dog).mother.name, 'Coco');
+});
+
+// eslint-disable-next-line max-len
+test('@JsonTypeInfo at parameter level (inside @JsonClass) with JsonTypeInfoAs.EXTERNAL_PROPERTY without subtypes name and using a custom @JsonTypeIdResolver', t => {
+  class CustomTypeIdResolver implements TypeIdResolver {
+    idFromValue(obj: any, options: (JsonStringifierTransformerContext | JsonParserTransformerContext)): string {
+      if (obj instanceof Dog) {
+        return 'animalDogType';
+      } else if (obj instanceof Cat) {
+        return 'animalCatType';
+      }
+      return null;
+    }
+    typeFromId(id: string, options: (JsonStringifierTransformerContext | JsonParserTransformerContext)): ClassType<any> {
+      switch (id) {
+      case 'animalDogType':
+        return Dog;
+      case 'animalCatType':
+        return Cat;
+      }
+      return null;
+    };
+  }
+
+  class Zoo {
+    @JsonProperty()
+    @JsonClassType({type: () => [Animal]})
+    animal: Animal;
+
+    constructor(
+    @JsonClassType({type: () => [
+      () => ({
+        target: Animal,
+        decorators: [
+          {
+            name: 'JsonTypeInfo',
+            options: {
+              use: JsonTypeInfoId.NAME,
+              include: JsonTypeInfoAs.EXTERNAL_PROPERTY,
+              property: 'animalType'
+            }
+          },
+          {
+            name: 'JsonTypeIdResolver',
+            options: {
+              resolver: new CustomTypeIdResolver()
+            }
+          }
+        ]
+      })
+    ]})
+      animal: Animal) {
+      this.animal = animal;
+    }
+  }
+
+  class Animal {
+    @JsonProperty() @JsonClassType({type: () => [String]})
+    name: string;
+
+    constructor(name: string) {
+      this.name = name;
+    }
+  }
+
+  class Dog extends Animal {
+    @JsonProperty()
+    @JsonClassType({type: () => [Dog]})
+    father: Dog;
+    @JsonProperty()
+    @JsonClassType({type: () => [Dog]})
+    mother: Dog;
+  }
+
+  class Cat extends Animal {
+
+  }
+
+  const objectMapper = new ObjectMapper();
+  // eslint-disable-next-line max-len
+  const jsonData = '{"animal":{"name":"Arthur","father":{"name":"Buddy"},"mother":{"name":"Coco"}},"animalType":"animalDogType"}';
+
+  const zooParsed = objectMapper.parse<Zoo>(jsonData, {mainCreator: () => [Zoo]});
+  t.assert(zooParsed instanceof Zoo);
+  t.assert(zooParsed.animal instanceof Dog);
+  t.is(zooParsed.animal.name, 'Arthur');
+  t.assert((zooParsed.animal as Dog).father instanceof Dog);
+  t.is((zooParsed.animal as Dog).father.name, 'Buddy');
+  t.assert((zooParsed.animal as Dog).mother instanceof Dog);
+  t.is((zooParsed.animal as Dog).mother.name, 'Coco');
+});
+
+test('@JsonTypeInfo with JsonTypeInfoAs.EXTERNAL_PROPERTY with subtypes name', t => {
+  @JsonTypeInfo({
+    use: JsonTypeInfoId.NAME,
+    include: JsonTypeInfoAs.EXTERNAL_PROPERTY,
+    property: 'animalType',
+  })
+  @JsonSubTypes({
+    types: [
+      {class: () => Dog, name: 'dog'},
+      {class: () => Cat, name: 'cat'},
+    ]
+  })
+  class Animal {
+    @JsonProperty() @JsonClassType({type: () => [String]})
+    name: string;
+
+    constructor(name: string) {
+      this.name = name;
+    }
+  }
+
+  @JsonTypeName({value: 'dog'})
+  class Dog extends Animal {
+
+  }
+
+  @JsonTypeName({value: 'cat'})
+  class Cat extends Animal {
+
+  }
+
+  const dog = new Dog('Arthur');
+  const cat = new Cat('Merlin');
+
+  const objectMapper = new ObjectMapper();
+  const jsonData = objectMapper.stringify<Array<Animal>>([dog, cat]);
+  t.deepEqual(JSON.parse(jsonData), JSON.parse('[{"name":"Arthur","animalType":"dog"},{"name":"Merlin","animalType":"cat"}]'));
+
+  const animals = objectMapper.parse<Array<Animal>>(jsonData, {mainCreator: () => [Array, [Animal]]});
+  t.assert(animals instanceof Array);
+  t.is(animals.length, 2);
+  t.assert(animals[0] instanceof Dog);
+  t.is(animals[0].name, 'Arthur');
+  t.assert(animals[1] instanceof Cat);
+  t.is(animals[1].name, 'Merlin');
+});
+
+// Appears that test @ lin 794 is minamed and is actually a wrapper object test
+//
+// test('@JsonTypeInfo with JsonTypeInfoAs.EXTERNAL_PROPERTY with @JsonTypeId', t => {
+//   @JsonTypeInfo({
+//     use: JsonTypeInfoId.NAME,
+//     include: JsonTypeInfoAs.WRAPPER_OBJECT,
+//     property: 'animalType',
+//   })
+//   @JsonSubTypes({
+//     types: [
+//       {class: () => Dog, name: 'dog'},
+//       {class: () => Cat, name: 'cat'},
+//     ]
+//   })
+//   class Animal {
+//     @JsonProperty() @JsonClassType({type: () => [String]})
+//     name: string;
+
+//     constructor(name: string) {
+//       this.name = name;
+//     }
+//   }
+
+//   @JsonTypeName({value: 'dog'})
+//   class Dog extends Animal {
+//     @JsonTypeId() @JsonClassType({type: () => [String]})
+//     typeId: string;
+//   }
+
+//   @JsonTypeName({value: 'cat'})
+//   class Cat extends Animal {
+//     @JsonTypeId()
+//     getTypeId(): string {
+//       return 'CatTypeId';
+//     }
+//   }
+
+//   const dog = new Dog('Arthur');
+//   dog.typeId = 'DogTypeId';
+
+//   const cat = new Cat('Merlin');
+
+//   const objectMapper = new ObjectMapper();
+//   const jsonData = objectMapper.stringify<Array<Animal>>([dog, cat]);
+//   t.deepEqual(JSON.parse(jsonData), JSON.parse('[{"DogTypeId":{"name":"Arthur"}},{"CatTypeId":{"name":"Merlin"}}]'));
+
+//   const err1 = t.throws<JacksonError>(() => {
+//     objectMapper.parse<Array<Animal>>(jsonData, {mainCreator: () => [Array, [Animal]]});
+//   });
+
+//   t.assert(err1 instanceof JacksonError);
+
+//   const err2 = t.throws<JacksonError>(() => {
+//     // eslint-disable-next-line max-len
+//     objectMapper.parse<Array<Animal>>('[{"dog":{"name":"Arthur"}},{"CatTypeId":{"name":"Merlin"}}]', {mainCreator: () => [Array, [Animal]]});
+//   });
+
+//   t.assert(err2 instanceof JacksonError);
+
+//   const err3 = t.throws<JacksonError>(() => {
+//     // eslint-disable-next-line max-len
+//     objectMapper.parse<Array<Animal>>('[{"DogTypeId":{"name":"Arthur"}},{"cat":{"name":"Merlin"}}]', {mainCreator: () => [Array, [Animal]]});
+//   });
+
+//   t.assert(err3 instanceof JacksonError);
+
+//   // eslint-disable-next-line max-len
+//   const animals = objectMapper.parse<Array<Animal>>('[{"dog":{"name":"Arthur"}},{"cat":{"name":"Merlin"}}]', {mainCreator: () => [Array, [Animal]]});
+//   t.assert(animals instanceof Array);
+//   t.is(animals.length, 2);
+//   t.assert(animals[0] instanceof Dog);
+//   t.is(animals[0].name, 'Arthur');
+//   t.assert(animals[1] instanceof Cat);
+//   t.is(animals[1].name, 'Merlin');
+// });
+
+test('@JsonTypeInfo with JsonTypeInfoAs.EXTERNAL_PROPERTY and custom property value', t => {
+  @JsonTypeInfo({
+    use: JsonTypeInfoId.NAME,
+    include: JsonTypeInfoAs.EXTERNAL_PROPERTY,
+    property: 'myType'
+  })
+  @JsonSubTypes({
+    types: [
+      {class: () => Dog, name: 'dog'},
+      {class: () => Cat, name: 'cat'},
+    ]
+  })
+  class Animal {
+    @JsonProperty() @JsonClassType({type: () => [String]})
+    name: string;
+
+    constructor(name: string) {
+      this.name = name;
+    }
+  }
+
+  @JsonTypeName({value: 'dog'})
+  class Dog extends Animal {
+
+  }
+
+  @JsonTypeName({value: 'cat'})
+  class Cat extends Animal {
+
+  }
+
+  const dog = new Dog('Arthur');
+  const cat = new Cat('Merlin');
+
+  const objectMapper = new ObjectMapper();
+  const jsonData = objectMapper.stringify<Array<Animal>>([dog, cat]);
+  t.deepEqual(JSON.parse(jsonData), JSON.parse('[{"name":"Arthur","myType":"dog"},{"name":"Merlin","myType":"cat"}]'));
+
+  const animals = objectMapper.parse<Array<Animal>>(jsonData, {mainCreator: () => [Array, [Animal]]});
+  t.assert(animals instanceof Array);
+  t.is(animals.length, 2);
+  t.assert(animals[0] instanceof Dog);
+  t.is(animals[0].name, 'Arthur');
+  t.assert(animals[1] instanceof Cat);
+  t.is(animals[1].name, 'Merlin');
+});
+


### PR DESCRIPTION
This mimics the `EXTERNAL_PROPERTY` mode from Jackson to support so-called “natural” type-info properties.

If used on a propery/method/parameter level type it will look for the named type-info property at the current JSON object level (i.e. as a sibling property to the property being deserialized).

If used on a top level type it works identically to `JsonTypeInfoAs.PROPERTY`. This appears to be so that it saves repeating the type-info annotations on every usage (as long as the same “property” name is always used).

The type-info will not be present in the deserialized object unless it is defined on the class independently.

#### Implementation

1. ~~`_propertyParentCreator` was changed to be an object `_propertyParent` that carries both the creator and parent instance.~~
   ~~This allows the code that parses the type-info to introspect the parent object for type information as is required.~~
   
   These changes were optimized away. The correct current parent is now just passed down the hierarchy as needed.

1. ~~`syntheticKeys` was added to parser context to report keys that should be ignored at a specific level as dictated by processing of a specific property.~~

   These changes were optimized away. I discovered I could compute the "synthetic keys" fairly easily.

1. ~~There are a few `cloneDeeps` that were edited to pass the `_propertyParent` and `syntheticKeys` down so that the type-info property could be deleted from the parent object and synthetic keys list could be updated.~~
   
   All changes to any cloning behavior or `cloneDeeps` have been removed.

1. "Unknown properties" are now reported a group after all are tested. This allows the "synthetic keys" to be removed from the list before reporting any unknowns. Also, due to properties being in any order we need to process all properties before we can determine which might be synthetic.

1. All of the tests for `JsonTypeInfoAs.PROPERTY` were copied and updated to be `JsonTypeInfoAs.EXTERNAL_PROPERTY` tests. I think this is a good start but I'm sure a few more wouldn't hurt.

## Connection with issue(s)

No issue was opened prior to this PR.

## Testing and Review Notes

All of the tests pass!! ~There are 3 tests failing during local execution prior to the changes in the PR being applied and appear to not be affected by these changes.~ No test issues when using PR #5 

## To Do

Nada 😉