### PR TITLE
fix(tests): Execute tests in UTC timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "build:dev": "npm run clean && ./node_modules/.bin/webpack --config webpack.dev.js",
     "build:prod": "npm run clean && ./node_modules/.bin/webpack --config webpack.prod.js",
     "start:node:dev": "node dist/lib.node",
-    "test-es5": "TS_NODE_PROJECT=tsconfig.json ava --concurrency=8 --timeout=3m --verbose",
-    "test-es6": "TS_NODE_PROJECT=tsconfig.es6.json ava --concurrency=8 --timeout=3m --verbose",
+    "test-es5": "TZ=UTC TS_NODE_PROJECT=tsconfig.json ava --concurrency=8 --timeout=3m --verbose",
+    "test-es6": "TZ=UTC TS_NODE_PROJECT=tsconfig.es6.json ava --concurrency=8 --timeout=3m --verbose",
     "test": "nyc npm run test-es5 && nyc --no-clean npm run test-es6",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },


### PR DESCRIPTION
At least 4 tests can fail when executed in random timezones due to date/time calculations. This fixes and stabilizes all tests with date/time calculations.

## Connection with issue(s)

No previous issue filed.

## Testing and Review Notes

This just ensures the tests run correctly in all timezones. It does not affect any library code.

## To Do

No outstanding items.
