### PR TITLE
fix(custom-serializers): Allows custom deserialization for classes with no default constructor

### DIFF
--- a/src/core/JsonStringifier.ts
+++ b/src/core/JsonStringifier.ts
@@ -302,7 +302,11 @@ export class JsonStringifier<T> {
 
     const currentMainCreator = context.mainCreator[0];
 
-    value = this.invokeCustomSerializers(key, value, context);
+    const { found: customSerialized, value: customValue } = this.invokeCustomSerializers(key, value, context);
+    if (customSerialized) {
+      return customValue;
+    }
+
     value = this.stringifyJsonSerializeClass(value, context);
 
     if (value == null && isConstructorPrimitiveType(context.mainCreator[0])) {
@@ -526,7 +530,7 @@ export class JsonStringifier<T> {
    * @param value
    * @param context
    */
-  private invokeCustomSerializers(key: string, value: any, context: JsonStringifierTransformerContext): any {
+  private invokeCustomSerializers(key: string, value: any, context: JsonStringifierTransformerContext): { value: any; found: boolean } {
     if (context.serializers) {
       const currentMainCreator = context.mainCreator[0];
       for (const serializer of context.serializers) {
@@ -540,10 +544,13 @@ export class JsonStringifier<T> {
             continue;
           }
         }
-        value = serializer.mapper(key, value, context);
+        return {
+          found: true,
+          value: serializer.mapper(key, value, context),
+        };
       }
     }
-    return value;
+    return { value: undefined, found: false };
   }
 
   /**


### PR DESCRIPTION
Some classes (e.g. `URL`) cannot be instantiated without specifically valid data and other claseses (e.g. luxon’s `DateTime` require static constructors).  Using these classes causes failures.

The current mainline code attempts to “transform” values that were deserialized using a custom deserializer; this attempted transformation causes failures after the custom deserializer has already successfully deserialized the value.

Not only does this cause the aforementioned issue but it also appears to be _incorrect_. The custom deserializer has already “done the work” and completely deserialized the value; there should be no need to attempt to keep transforming the value further.

**The fix was to return the value immediately after a custom deserializer is found.**

NOTE: Although no issues appeared with `JsonStringifier` using types like `URL` and `DateTime`, the same code exists and, as I stated previously, this appears to be incorrect.  That being said, I made the equivalent change to `JsonStringifier` for parity.

## Connection with issue(s)

No previous issue filed.

## Testing and Review Notes

All tests pass! 

Note that some of the serialization tests perform date calculations.  PR #5 must be applied to ensure these tests always succeed.

## To Do

Nothing.
