### PR TITLE
fix(minify): support minified client packages

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -500,11 +500,11 @@ export const getArgumentNames = (method): string[] => {
     return [];
   }
 
-  if (code.startsWith('class extends')) {
-    code = 'class JacksonClass ' + code.substring(6);
-  } else if (code.startsWith('function (')) {
+  if (/^class({| extends)/.test(code)) {
+    code = 'class JacksonClass ' + code.substring(5);
+  } else if (/^function\s?\(/.test(code)) {
     code = 'function JacksonFunction ' + code.substring(9);
-  } else if (!code.startsWith('class ') && !code.startsWith('function ')) {
+  } else if (!/^class\s?/.test(code) && !/^function\s?/.test(code)) {
     code = 'function ' + code;
   }
 


### PR DESCRIPTION
The `getArgumentNames` function was fixed to resolve a few issues with minification as detailed below.

### Whitespace
`getArgumentNames` tests for specific code pieces but assumes whitespace that may be removed by minification.  The tests are changed to use regex’s that make the space optional.

### `class extend` vs `class`
After minification code arises like the following:
```
class{constructor(e,t,r,n,i,a,o){this.id=e,this.aliases=t,this.caCertificate=r,this.hash=n,this.inception=i,this.deviceCount=a,this.data=o}}
```
Notice the lack of `extends` after `class`. This causes the `class extends` test to fail and causes a syntax error for the missing class name. This regex was altered to make the test for `extends` or the `{`, which causes replacement with `class JacksonClass` as required.

## Connection with issue(s)

Resolve issue #7 

## Testing and Review Notes

All test pass.

## To Do

Adding proper tests for this scenario requires minifying a client class that uses decorators from this package. Alternatively a number of strings of pre-minified code could be added, testing them against `getArgumentNames` directly.

For example:
```
const names = getArgumentNames('class{constructor(e,t,r,n,i,a,o){this.id=e,this.aliases=t,this.caCertificate=r,this.hash=n,this.inception=i,this.deviceCount=a,this.data=o}}')

expect(names).toEqual(['e','t','r','n','I','a','o']);
```

Which of these methods is best and should be implemented is a decision left for the package maintainer.