### PR TITLE
task(pkg): add source maps to production build

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -24,6 +24,7 @@ const defaultConfig = {
   resolve: {
     extensions: ['.tsx', '.ts', '.js']
   },
+  devtool: 'source-map',
   mode: 'production',
   plugins: []
 };


### PR DESCRIPTION
Considering this is an open source project, enabling source maps in webpack proves very helpful without revealing anything proprietary.

External source-maps are generated in production to ensure download sizes are still small.

## Connection with issue(s)

No related issues.

## Testing and Review Notes

All tests pass.

## To Do

Nothing.
