### PR TITLE
fix(bigint): Use typeof for testing if BigInt exists

### DIFF
--- a/src/core/JsonParser.ts
+++ b/src/core/JsonParser.ts
@@ -11,6 +11,7 @@ import {
   getDefaultPrimitiveTypeValue,
   getMetadata,
   getMetadataKeys,
+  hasBigInt,
   hasMetadata,
   isClassIterable,
   isConstructorPrimitiveType,
@@ -284,7 +285,7 @@ export class JsonParser<T> {
       if (value.constructor === String) {
         if (isSameConstructorOrExtensionOfNoObject(currentMainCreator, Number)) {
           value = +value;
-        } else if (BigInt && isSameConstructorOrExtensionOfNoObject(currentMainCreator, BigInt)) {
+        } else if (hasBigInt && isSameConstructorOrExtensionOfNoObject(currentMainCreator, BigInt)) {
           value = BigInt(+value);
         } else if (isSameConstructorOrExtensionOfNoObject(currentMainCreator, Boolean)) {
           if (value.toLowerCase() === 'true' || value === '1') {
@@ -298,7 +299,7 @@ export class JsonParser<T> {
       } else if (value.constructor === Number) {
         if (isSameConstructorOrExtensionOfNoObject(currentMainCreator, Boolean)) {
           value = !!value;
-        } else if (BigInt && isSameConstructorOrExtensionOfNoObject(currentMainCreator, BigInt)) {
+        } else if (hasBigInt && isSameConstructorOrExtensionOfNoObject(currentMainCreator, BigInt)) {
           value = BigInt(+value);
         } else if (isSameConstructorOrExtensionOfNoObject(currentMainCreator, String)) {
           // @ts-ignore
@@ -307,7 +308,7 @@ export class JsonParser<T> {
       } else if (value.constructor === Boolean) {
         if (isSameConstructorOrExtensionOfNoObject(currentMainCreator, Number)) {
           value = value ? 1 : 0;
-        } else if (BigInt && isSameConstructorOrExtensionOfNoObject(currentMainCreator, BigInt)) {
+        } else if (hasBigInt && isSameConstructorOrExtensionOfNoObject(currentMainCreator, BigInt)) {
           value = BigInt(value ? 1 : 0);
         } else if (isSameConstructorOrExtensionOfNoObject(currentMainCreator, String)) {
           // @ts-ignore
@@ -353,7 +354,7 @@ export class JsonParser<T> {
       if (isSameConstructorOrExtensionOfNoObject(currentMainCreator, Map) ||
           (typeof value === 'object' && !isIterableNoMapNoString(value) && currentMainCreator === Object)) {
         return this.parseMapAndObjLiteral(key, value, context, globalContext);
-      } else if (BigInt && isSameConstructorOrExtensionOfNoObject(currentMainCreator, BigInt)) {
+      } else if (hasBigInt && isSameConstructorOrExtensionOfNoObject(currentMainCreator, BigInt)) {
         return (value != null && value.constructor === String && value.endsWith('n')) ?
           // @ts-ignore
           currentMainCreator(value.substring(0, value.length - 1)) :
@@ -459,7 +460,7 @@ export class JsonParser<T> {
       (context.features.deserialization.SET_DEFAULT_VALUE_FOR_PRIMITIVES_ON_NULL ||
         context.features.deserialization.SET_DEFAULT_VALUE_FOR_BOOLEAN_ON_NULL) ) {
       defaultValue = getDefaultPrimitiveTypeValue(Boolean);
-    } else if (BigInt && currentMainCreator === BigInt &&
+    } else if (hasBigInt && currentMainCreator === BigInt &&
       (context.features.deserialization.SET_DEFAULT_VALUE_FOR_PRIMITIVES_ON_NULL ||
         context.features.deserialization.SET_DEFAULT_VALUE_FOR_BIGINT_ON_NULL) ) {
       defaultValue = getDefaultPrimitiveTypeValue(BigInt);

--- a/src/core/JsonStringifier.ts
+++ b/src/core/JsonStringifier.ts
@@ -54,6 +54,7 @@ import {
   getDefaultValue,
   getMetadata,
   getObjectKeysWithPropertyDescriptorNames,
+  hasBigInt,
   hasMetadata,
   isConstructorPrimitiveType,
   isIterableNoMapNoString,
@@ -337,7 +338,7 @@ export class JsonStringifier<T> {
 
       value = this.stringifyJsonFormatClass(value, context);
 
-      if (BigInt && isSameConstructorOrExtensionOfNoObject(value.constructor, BigInt)) {
+      if (hasBigInt && isSameConstructorOrExtensionOfNoObject(value.constructor, BigInt)) {
         return value.toString() + 'n';
       } else if (value instanceof RegExp) {
         const replacement = value.toString();
@@ -565,7 +566,7 @@ export class JsonStringifier<T> {
       (context.features.serialization.SET_DEFAULT_VALUE_FOR_PRIMITIVES_ON_NULL ||
         context.features.serialization.SET_DEFAULT_VALUE_FOR_BOOLEAN_ON_NULL) ) {
       defaultValue = getDefaultPrimitiveTypeValue(Boolean);
-    } else if (BigInt && currentMainCreator === BigInt &&
+    } else if (hasBigInt && currentMainCreator === BigInt &&
       (context.features.serialization.SET_DEFAULT_VALUE_FOR_PRIMITIVES_ON_NULL ||
         context.features.serialization.SET_DEFAULT_VALUE_FOR_BIGINT_ON_NULL) ) {
       defaultValue = getDefaultPrimitiveTypeValue(BigInt);

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,6 +22,11 @@ import {
 } from './core/DefaultContextGroup';
 
 /**
+ * Flag for testing if BigInt is supported
+ */
+export const hasBigInt = typeof BigInt !== 'undefined';
+
+/**
  * @internal
  */
 export interface MakeMetadataKeyWithContextOptions {
@@ -824,7 +829,7 @@ export const isVariablePrimitiveType = (value: any): boolean => value != null &&
  * @internal
  */
 export const isConstructorPrimitiveType = (ctor: any): boolean => ctor === Number ||
-  (BigInt && ctor === BigInt) || ctor === String ||
+  (hasBigInt && ctor === BigInt) || ctor === String ||
   ctor === Boolean || (Symbol && ctor === Symbol);
 
 /**
@@ -839,7 +844,7 @@ export const getDefaultPrimitiveTypeValue = (ctor: ClassType<any>): any | null =
   case String:
     return '';
   default:
-    if (BigInt && ctor === BigInt) {
+    if (hasBigInt && ctor === BigInt) {
       return BigInt(0);
     }
   }


### PR DESCRIPTION
The `if (BigInt) { … }` style does not work in browser environments that do not implement BigInt (e.g. Safari <= 13).

A `hasBigInt` flag was added and exported from `util` and uses the format of `typeof BigInt !== ‘undefined’` which should work in all environments.  All usage of `BigInt` is now guarded by an equivalent of `if (hasBigInt) {…}` to ensure it’s available before use.

## Connection with issue(s)

Resolve issue #11 

## Testing and Review Notes

None

## To Do

N/A
