### PR TITLE
fix: generify check for “native code”

### DIFF
--- a/src/decorators/JsonAlias.ts
+++ b/src/decorators/JsonAlias.ts
@@ -3,7 +3,7 @@
  * @module Decorators
  */
 
-import {defineMetadata, makeJacksonDecorator} from '../util';
+import {defineMetadata, isNativeCode, makeJacksonDecorator} from '../util';
 import {JsonAliasDecorator, JsonAliasOptions} from '../@types';
 
 /**
@@ -39,7 +39,7 @@ export const JsonAlias: JsonAliasDecorator = makeJacksonDecorator(
     }
     if (descriptorOrParamIndex != null && typeof descriptorOrParamIndex === 'number') {
       defineMetadata('JsonAliasParam',
-        options, (target.constructor.toString().endsWith('{ [native code] }')) ? target : target.constructor,
+        options, (isNativeCode(target.constructor)) ? target : target.constructor,
         (propertyKey) ? propertyKey : 'constructor', {
           suffix: descriptorOrParamIndex.toString()
         });

--- a/src/decorators/JsonClassType.ts
+++ b/src/decorators/JsonClassType.ts
@@ -3,7 +3,7 @@
  * @module Decorators
  */
 
-import {defineMetadata, makeJacksonDecorator} from '../util';
+import {defineMetadata, isNativeCode, makeJacksonDecorator} from '../util';
 import {JsonClassTypeDecorator, JsonClassTypeOptions} from '../@types';
 
 /**
@@ -46,7 +46,7 @@ export const JsonClassType: JsonClassTypeDecorator = makeJacksonDecorator(
     if (descriptorOrParamIndex != null && typeof descriptorOrParamIndex === 'number') {
       defineMetadata(
         'JsonClassTypeParam',
-        options, (target.constructor.toString().endsWith('{ [native code] }')) ? target : target.constructor,
+        options, (isNativeCode(target.constructor)) ? target : target.constructor,
         (propertyKey) ? propertyKey : 'constructor', {
           suffix: descriptorOrParamIndex.toString()
         });

--- a/src/decorators/JsonDeserialize.ts
+++ b/src/decorators/JsonDeserialize.ts
@@ -3,7 +3,7 @@
  * @module Decorators
  */
 
-import {defineMetadata, makeJacksonDecorator} from '../util';
+import {defineMetadata, isNativeCode, makeJacksonDecorator} from '../util';
 import {JsonDeserializeDecorator, JsonDeserializeOptions} from '../@types';
 
 /**
@@ -49,7 +49,7 @@ export const JsonDeserialize: JsonDeserializeDecorator = makeJacksonDecorator(
     if (descriptorOrParamIndex != null && typeof descriptorOrParamIndex === 'number') {
       defineMetadata(
         'JsonDeserializeParam',
-        options, (target.constructor.toString().endsWith('{ [native code] }')) ? target : target.constructor,
+        options, (isNativeCode(target.constructor)) ? target : target.constructor,
         (propertyKey) ? propertyKey : 'constructor', {
           suffix: descriptorOrParamIndex.toString()
         });

--- a/src/decorators/JsonIdentityInfo.ts
+++ b/src/decorators/JsonIdentityInfo.ts
@@ -3,7 +3,7 @@
  * @module Decorators
  */
 
-import {defineMetadata, makeJacksonDecorator} from '../util';
+import {defineMetadata, isNativeCode, makeJacksonDecorator} from '../util';
 import {
   JsonIdentityInfoDecorator,
   JsonIdentityInfoOptions
@@ -106,7 +106,7 @@ export const JsonIdentityInfo: JsonIdentityInfoDecorator = makeJacksonDecorator(
     if (descriptorOrParamIndex != null && typeof descriptorOrParamIndex === 'number') {
       defineMetadata(
         'JsonIdentityInfoParam',
-        options, (target.constructor.toString().endsWith('{ [native code] }')) ? target : target.constructor,
+        options, (isNativeCode(target.constructor)) ? target : target.constructor,
         (propertyKey) ? propertyKey : 'constructor', {
           suffix: descriptorOrParamIndex.toString()
         });

--- a/src/decorators/JsonIdentityReference.ts
+++ b/src/decorators/JsonIdentityReference.ts
@@ -3,7 +3,7 @@
  * @module Decorators
  */
 
-import {defineMetadata, makeJacksonDecorator} from '../util';
+import {defineMetadata, isNativeCode, makeJacksonDecorator} from '../util';
 import {
   JsonIdentityReferenceDecorator,
   JsonIdentityReferenceOptions
@@ -61,7 +61,7 @@ export const JsonIdentityReference: JsonIdentityReferenceDecorator = makeJackson
     if (descriptorOrParamIndex != null && typeof descriptorOrParamIndex === 'number') {
       defineMetadata(
         'JsonIdentityReferenceParam',
-        options, (target.constructor.toString().endsWith('{ [native code] }')) ? target : target.constructor,
+        options, (isNativeCode(target.constructor)) ? target : target.constructor,
         (propertyKey) ? propertyKey : 'constructor', {
           suffix: descriptorOrParamIndex.toString()
         });

--- a/src/decorators/JsonIgnore.ts
+++ b/src/decorators/JsonIgnore.ts
@@ -3,7 +3,7 @@
  * @module Decorators
  */
 
-import {defineMetadata, makeJacksonDecorator} from '../util';
+import {defineMetadata, isNativeCode, makeJacksonDecorator} from '../util';
 import {JsonIgnoreDecorator, JsonIgnoreOptions} from '../@types';
 
 /**
@@ -33,7 +33,7 @@ export const JsonIgnore: JsonIgnoreDecorator = makeJacksonDecorator(
     }
     if (descriptorOrParamIndex != null && typeof descriptorOrParamIndex === 'number') {
       defineMetadata('JsonIgnoreParam',
-        options, (target.constructor.toString().endsWith('{ [native code] }')) ? target : target.constructor,
+        options, (isNativeCode(target.constructor)) ? target : target.constructor,
         (propertyKey) ? propertyKey : 'constructor', {
           suffix: descriptorOrParamIndex.toString()
         });

--- a/src/decorators/JsonIgnoreProperties.ts
+++ b/src/decorators/JsonIgnoreProperties.ts
@@ -3,7 +3,7 @@
  * @module Decorators
  */
 
-import {defineMetadata, makeJacksonDecorator} from '../util';
+import {defineMetadata, isNativeCode, makeJacksonDecorator} from '../util';
 import {JsonIgnorePropertiesDecorator, JsonIgnorePropertiesOptions} from '../@types';
 
 /**
@@ -48,7 +48,7 @@ export const JsonIgnoreProperties: JsonIgnorePropertiesDecorator = makeJacksonDe
     if (descriptorOrParamIndex != null && typeof descriptorOrParamIndex === 'number') {
       defineMetadata(
         'JsonIgnorePropertiesParam',
-        options, (target.constructor.toString().endsWith('{ [native code] }')) ? target : target.constructor,
+        options, (isNativeCode(target.constructor)) ? target : target.constructor,
         (propertyKey) ? propertyKey : 'constructor', {
           suffix: descriptorOrParamIndex.toString()
         });

--- a/src/decorators/JsonInject.ts
+++ b/src/decorators/JsonInject.ts
@@ -3,7 +3,7 @@
  * @module Decorators
  */
 
-import {defineMetadata, getArgumentNames, makeJacksonDecorator} from '../util';
+import {defineMetadata, getArgumentNames, isNativeCode, makeJacksonDecorator} from '../util';
 import {JsonInjectDecorator, JsonInjectOptions} from '../@types';
 import {JacksonError} from '../core/JacksonError';
 
@@ -56,7 +56,7 @@ export const JsonInject: JsonInjectDecorator = makeJacksonDecorator(
       }
 
       defineMetadata('JsonInjectParam',
-        options, (target.constructor.toString().endsWith('{ [native code] }')) ? target : target.constructor,
+        options, (isNativeCode(target.constructor)) ? target : target.constructor,
         (propertyKey) ? propertyKey : 'constructor', {
           suffix: descriptorOrParamIndex.toString()
         });
@@ -73,7 +73,7 @@ export const JsonInject: JsonInjectDecorator = makeJacksonDecorator(
         }
         if (!options.value) {
           // eslint-disable-next-line max-len
-          throw new JacksonError(`Invalid usage of @JsonInject() on ${((target.constructor.toString().endsWith('{ [native code] }')) ? target : target.constructor).name}.${propertyKey.toString()}. You must either define a non-empty @JsonInject() option value or change the method name starting with "get" for Getters or "set" for Setters.`);
+          throw new JacksonError(`Invalid usage of @JsonInject() on ${((isNativeCode(target.constructor)) ? target : target.constructor).name}.${propertyKey.toString()}. You must either define a non-empty @JsonInject() option value or change the method name starting with "get" for Getters or "set" for Setters.`);
         }
       }
       defineMetadata('JsonInject', options, target.constructor, propertyKey);

--- a/src/decorators/JsonProperty.ts
+++ b/src/decorators/JsonProperty.ts
@@ -3,7 +3,7 @@
  * @module Decorators
  */
 
-import {defineMetadata, getArgumentNames, makeJacksonDecorator} from '../util';
+import {defineMetadata, getArgumentNames, isNativeCode, makeJacksonDecorator} from '../util';
 import {JsonPropertyDecorator, JsonPropertyOptions} from '../@types';
 import {JacksonError} from '../core/JacksonError';
 
@@ -90,7 +90,7 @@ export const JsonProperty: JsonPropertyDecorator = makeJacksonDecorator(
         }
         if (!options.value) {
           // eslint-disable-next-line max-len
-          throw new JacksonError(`Invalid usage of @JsonProperty() on ${((target.constructor.toString().endsWith('{ [native code] }')) ? target : target.constructor).name}.${propertyKey.toString()}. You must either define a non-empty @JsonProperty() option value or change the method name starting with "get" for Getters or "set" for Setters.`);
+          throw new JacksonError(`Invalid usage of @JsonProperty() on ${(isNativeCode(target.constructor) ? target : target.constructor).name}.${propertyKey.toString()}. You must either define a non-empty @JsonProperty() option value or change the method name starting with "get" for Getters or "set" for Setters.`);
         }
       } else {
         options.value = propertyKey.toString();
@@ -106,7 +106,7 @@ export const JsonProperty: JsonPropertyDecorator = makeJacksonDecorator(
 
       defineMetadata(
         'JsonPropertyParam',
-        options, (target.constructor.toString().endsWith('{ [native code] }')) ? target : target.constructor,
+        options, isNativeCode(target.constructor) ? target : target.constructor,
         (propertyKey) ? propertyKey : 'constructor', {
           suffix: descriptorOrParamIndex.toString()
         });

--- a/src/decorators/JsonPropertyOrder.ts
+++ b/src/decorators/JsonPropertyOrder.ts
@@ -3,7 +3,7 @@
  * @module Decorators
  */
 
-import {makeJacksonDecorator, defineMetadata} from '../util';
+import {makeJacksonDecorator, defineMetadata, isNativeCode} from '../util';
 import {JsonPropertyOrderDecorator, JsonPropertyOrderOptions} from '../@types';
 
 /**
@@ -45,7 +45,7 @@ export const JsonPropertyOrder: JsonPropertyOrderDecorator = makeJacksonDecorato
     if (descriptorOrParamIndex != null && typeof descriptorOrParamIndex === 'number') {
       defineMetadata(
         'JsonPropertyOrderParam',
-        options, (target.constructor.toString().endsWith('{ [native code] }')) ? target : target.constructor,
+        options, (isNativeCode(target.constructor)) ? target : target.constructor,
         (propertyKey) ? propertyKey : 'constructor', {
           suffix: descriptorOrParamIndex.toString()
         });

--- a/src/decorators/JsonSubTypes.ts
+++ b/src/decorators/JsonSubTypes.ts
@@ -3,7 +3,7 @@
  * @module Decorators
  */
 
-import {makeJacksonDecorator, defineMetadata} from '../util';
+import {makeJacksonDecorator, defineMetadata, isNativeCode} from '../util';
 import {JsonSubTypesDecorator, JsonSubTypesOptions} from '../@types';
 
 /**
@@ -51,7 +51,7 @@ export const JsonSubTypes: JsonSubTypesDecorator = makeJacksonDecorator(
     if (descriptorOrParamIndex != null && typeof descriptorOrParamIndex === 'number') {
       defineMetadata(
         'JsonSubTypesParam',
-        options, (target.constructor.toString().endsWith('{ [native code] }')) ? target : target.constructor,
+        options, (isNativeCode(target.constructor)) ? target : target.constructor,
         (propertyKey) ? propertyKey : 'constructor', {
           suffix: descriptorOrParamIndex.toString()
         });

--- a/src/decorators/JsonTypeIdResolver.ts
+++ b/src/decorators/JsonTypeIdResolver.ts
@@ -3,7 +3,7 @@
  * @module Decorators
  */
 
-import {defineMetadata, makeJacksonDecorator} from '../util';
+import {defineMetadata, isNativeCode, makeJacksonDecorator} from '../util';
 import {JsonTypeIdResolverDecorator, JsonTypeIdResolverOptions} from '../@types';
 
 /**
@@ -62,7 +62,7 @@ export const JsonTypeIdResolver: JsonTypeIdResolverDecorator = makeJacksonDecora
     if (descriptorOrParamIndex != null && typeof descriptorOrParamIndex === 'number') {
       defineMetadata(
         'JsonTypeIdResolverParam',
-        options, (target.constructor.toString().endsWith('{ [native code] }')) ? target : target.constructor,
+        options, (isNativeCode(target.constructor)) ? target : target.constructor,
         (propertyKey) ? propertyKey : 'constructor', {
           suffix: descriptorOrParamIndex.toString()
         });

--- a/src/decorators/JsonTypeInfo.ts
+++ b/src/decorators/JsonTypeInfo.ts
@@ -3,7 +3,7 @@
  * @module Decorators
  */
 
-import {defineMetadata, makeJacksonDecorator} from '../util';
+import {defineMetadata, isNativeCode, makeJacksonDecorator} from '../util';
 import {JsonTypeInfoDecorator, JsonTypeInfoOptions} from '../@types';
 
 /**
@@ -94,7 +94,7 @@ export const JsonTypeInfo: JsonTypeInfoDecorator = makeJacksonDecorator(
     if (descriptorOrParamIndex != null && typeof descriptorOrParamIndex === 'number') {
       defineMetadata(
         'JsonTypeInfoParam',
-        options, (target.constructor.toString().endsWith('{ [native code] }')) ? target : target.constructor,
+        options, (isNativeCode(target.constructor)) ? target : target.constructor,
         (propertyKey) ? propertyKey : 'constructor', {
           suffix: descriptorOrParamIndex.toString()
         });

--- a/src/decorators/JsonView.ts
+++ b/src/decorators/JsonView.ts
@@ -3,7 +3,7 @@
  * @module Decorators
  */
 
-import {defineMetadata, makeJacksonDecorator} from '../util';
+import {defineMetadata, isNativeCode, makeJacksonDecorator} from '../util';
 import {JsonViewDecorator, JsonViewOptions} from '../@types';
 
 /**
@@ -65,7 +65,7 @@ export const JsonView: JsonViewDecorator = makeJacksonDecorator(
     if (descriptorOrParamIndex != null && typeof descriptorOrParamIndex === 'number') {
       defineMetadata(
         'JsonViewParam',
-        options, (target.constructor.toString().endsWith('{ [native code] }')) ? target : target.constructor,
+        options, (isNativeCode(target.constructor)) ? target : target.constructor,
         (propertyKey) ? propertyKey : 'constructor', {
           suffix: descriptorOrParamIndex.toString()
         });

--- a/src/util.ts
+++ b/src/util.ts
@@ -187,6 +187,16 @@ const pluckParamName = (param): string => {
   return;
 };
 
+const nativeCodeRegex = /{\s*\[native code]\s*}$/;
+
+/**
+ * Determines if the provided function is implemented in native code.
+ *
+ * @param value
+ * @internal
+ */
+export const isNativeCode = (value: Function | string): boolean => !!nativeCodeRegex.exec(value.toString());
+
 /**
  * @internal
  */
@@ -238,8 +248,8 @@ export const getClassProperties = (target: Record<string, any>, obj: any = null,
     objKeys = Object.keys(obj);
     if (objKeys.includes('constructor') &&
       typeof obj.constructor === 'function' &&
-      !obj.constructor.toString().endsWith('{ [native code] }') &&
-      obj.constructor.constructor.toString().endsWith('{ [native code] }')) {
+      !isNativeCode(obj.constructor) &&
+      isNativeCode(obj.constructor.constructor)) {
       objKeys.splice(objKeys.indexOf('constructor'), 1);
     }
   }
@@ -496,7 +506,7 @@ export const mapClassPropertyToVirtualProperty =
 export const getArgumentNames = (method): string[] => {
   let code = method.toString().trim();
 
-  if (code.endsWith(' { [native code] }')) {
+  if (isNativeCode(code)) {
     return [];
   }
 
@@ -891,8 +901,8 @@ export const getObjectKeysWithPropertyDescriptorNames = (obj: any, ctor: any,
 
   if (keys.includes('constructor') &&
     typeof obj.constructor === 'function' &&
-    !obj.constructor.toString().endsWith('{ [native code] }') &&
-    obj.constructor.constructor.toString().endsWith('{ [native code] }')) {
+    !isNativeCode(obj.constructor) &&
+    isNativeCode(obj.constructor.constructor)) {
     keys.splice(keys.indexOf('constructor'), 1);
   }
 


### PR DESCRIPTION
The checks for native code using `endsWith(‘{ [native code] }’)` do not work in Safari when code is packaged using webpack because Safari includs newlines in its native code output.

All native code checks have been centralized to a `isNativeCode` function exported from util and the check now uses a regex that allows for any type of white space.

## Connection with issue(s)

Resolve issue #13 

## Testing and Review Notes

As stated in issue, the problem is only exhibited when using Safari JS engine and the code using jackson-js is packaged using webpack.

## To Do

N/A
